### PR TITLE
MacOS compatibility 

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -18,11 +18,23 @@ jobs:
             - name: "Checkout sources"
               uses: actions/checkout@v2
 
-            - name: "Install Eigen and NumPy"
-              run: sudo apt-get install -y libeigen3-dev python3-numpy
+            - name: "Install Eigen"
+              if: runner.os == 'Linux'
+              run: sudo apt-get install -y libeigen3-dev
+
+            - name: "Install Eigen"
+              if: runner.os == 'macOS'
+              run: |
+                 brew update
+                 brew install eigen
+
+            - name: "Install Python"
+              uses: actions/setup-python@v4
+              with: 
+                python-version: '3.10'    
 
             - name: "Install PyPI dependencies"
-              run: pip install aiofiles msgpack
+              run: pip3 install aiofiles msgpack numpy
 
             - name: "Build the library"
               env:

--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -13,7 +13,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                os: [ubuntu-latest]
+                os: [ubuntu-latest, macos-latest]
         steps:
             - name: "Checkout sources"
               uses: actions/checkout@v2

--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -58,6 +58,9 @@ jobs:
               run: |
                   tools/bazelisk coverage --combined_report=lcov --instrument_test_targets --test_verbose_timeout_warnings //...
 
+            - name: Setup upterm session
+              uses: lhotari/action-upterm@v1
+
             - name: "Submit report to Coveralls"
               uses: coverallsapp/github-action@1.1.3
               with:

--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -56,7 +56,7 @@ jobs:
 
             - name: "Report test coverage"
               run: |
-                  tools/bazelisk coverage --combined_report=lcov --instrument_test_targets //...
+                  tools/bazelisk coverage --combined_report=lcov --instrument_test_targets --test_verbose_timeout_warnings //...
 
             - name: "Submit report to Coveralls"
               uses: coverallsapp/github-action@1.1.3

--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -57,7 +57,7 @@ jobs:
             - name: "Report test coverage"
               if: runner.os == 'Linux'
               run: |
-                  tools/bazelisk coverage --combined_report=lcov --instrument_test_targets --test_verbose_timeout_warnings //...
+                  tools/bazelisk coverage --combined_report=lcov --instrument_test_targets //...
 
             - name: "Submit report to Coveralls"
               if: runner.os == 'Linux'

--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -55,13 +55,12 @@ jobs:
                   tools/bazelisk test //...
 
             - name: "Report test coverage"
+              if: runner.os == 'Linux'
               run: |
                   tools/bazelisk coverage --combined_report=lcov --instrument_test_targets --test_verbose_timeout_warnings //...
 
-            - name: Setup upterm session
-              uses: lhotari/action-upterm@v1
-
             - name: "Submit report to Coveralls"
+              if: runner.os == 'Linux'
               uses: coverallsapp/github-action@1.1.3
               with:
                   github-token: ${{ secrets.github_token }}

--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -18,11 +18,11 @@ jobs:
             - name: "Checkout sources"
               uses: actions/checkout@v2
 
-            - name: "Install Eigen"
+            - name: "Install Eigen (Linux)"
               if: runner.os == 'Linux'
               run: sudo apt-get install -y libeigen3-dev
 
-            - name: "Install Eigen"
+            - name: "Install Eigen (macOS)"
               if: runner.os == 'macOS'
               run: |
                  brew update
@@ -34,7 +34,7 @@ jobs:
                 python-version: '3.10'    
 
             - name: "Install PyPI dependencies"
-              run: pip3 install aiofiles msgpack numpy
+              run: pip3 install aiofiles msgpack numpy six clang-format
 
             - name: "Build the library"
               env:

--- a/mpacklog/cpp/Logger.cpp
+++ b/mpacklog/cpp/Logger.cpp
@@ -37,7 +37,11 @@ Logger::Logger(const std::string &path, bool append) {
     throw std::runtime_error("Cannot open " + path + " for writing");
   }
   thread_ = std::thread([this]() {
+#ifdef __APPLE__
+    pthread_setname_np("logger_thread");
+#else
     pthread_setname_np(pthread_self(), "logger_thread");
+#endif
     while (keep_going_) {
       flush_buffer();
 


### PR DESCRIPTION
This PR introduces MacOS compatibility by using an alternative of the Linux-specific `pthread_setname_np` which has a different signature for MacOS.